### PR TITLE
docs: provide valid Google Drive folder ID example

### DIFF
--- a/env.example
+++ b/env.example
@@ -3,7 +3,6 @@ PORT=3000
 
 # ID папки в Google Drive для загрузки файлов
 # Получить ID можно из URL папки: https://drive.google.com/drive/folders/
-FOLDER_ID=1pxoAA-f2ICSvFswM0l7ByATEu1uFrmMt?usp
+# ID не должен содержать хвостовых параметров URL
+FOLDER_ID=1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms
 
-# Пример:
-# FOLDER_ID=1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms


### PR DESCRIPTION
## Summary
- replace sample Google Drive folder ID with one without URL parameters
- document that the ID must exclude trailing URL parameters

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b163837508832992e6a951e82f69c6