### PR TITLE
Pass file MIME type to Drive uploads

### DIFF
--- a/server.js
+++ b/server.js
@@ -93,7 +93,7 @@ async function initializeGoogleDrive() {
 }
 
 // Функция для загрузки файла в Google Drive
-async function uploadToGoogleDrive(filePath, originalName) {
+async function uploadToGoogleDrive(filePath, originalName, mimeType) {
     try {
         const fileMetadata = {
             name: originalName, // Сохраняем оригинальное имя файла
@@ -101,7 +101,7 @@ async function uploadToGoogleDrive(filePath, originalName) {
         };
 
         const media = {
-            mimeType: 'image/*',
+            mimeType: mimeType,
             body: fs.createReadStream(filePath)
         };
 
@@ -154,8 +154,9 @@ app.post('/upload', upload.single('image'), async (req, res) => {
 
         // Загружаем файл в Google Drive
         const uploadResult = await uploadToGoogleDrive(
-            req.file.path, 
-            req.file.originalname
+            req.file.path,
+            req.file.originalname,
+            req.file.mimetype
         );
 
         // Удаляем временный файл


### PR DESCRIPTION
## Summary
- Accept MIME type in `uploadToGoogleDrive`
- Forward `req.file.mimetype` so media uploads use the correct type

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1637a33dc83298dc52f3b5cb59b26