### PR TITLE
Handle non-JSON upload errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,19 +274,21 @@
                 const formData = new FormData();
                 formData.append('image', file);
 
-                const response = await fetch('/upload', {
+                const response = await fetch('/api/upload', {
                     method: 'POST',
                     body: formData
                 });
 
-                const data = await response.json();
+                const contentType = response.headers.get('content-type') || '';
+                if (response.ok && contentType.includes('application/json')) {
+                    const data = await response.json();
 
-                if (response.ok) {
                     showResult(`✅ Файл успешно загружен! ID: ${data.fileId}`, 'success');
                     form.reset();
                     selectedFile.style.display = 'none';
                 } else {
-                    showResult(`❌ Ошибка: ${data.error}`, 'error');
+                    const errorText = await response.text();
+                    showResult(`❌ Ошибка: ${errorText || 'Некорректный ответ сервера'}`, 'error');
                 }
             } catch (error) {
                 showResult(`❌ Ошибка сети: ${error.message}`, 'error');


### PR DESCRIPTION
## Summary
- update file upload to call `/api/upload`
- handle non-JSON server responses before parsing

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b188a812a483298532638d62e3f258